### PR TITLE
remove redundant default

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -20,7 +20,6 @@
   </ItemGroup>
   <PropertyGroup Label="MinVer">
     <MinVerMinimumMajorMinor>0.9</MinVerMinimumMajorMinor>
-    <MinVerDefaultPreReleasePhase>alpha</MinVerDefaultPreReleasePhase>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\*.cs" />


### PR DESCRIPTION
The "default default" is already `alpha`, and this will almost certainly never change.